### PR TITLE
chore(renovate): move config to .github and extend sneat-co/cicd preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,1 @@
+{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["config:recommended","github>sneat-co/cicd"]}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## What
Moves the root `renovate.json` to `.github/renovate.json`, adds `github>sneat-co/cicd` to the `extends` list, and normalizes `config:base` to `config:recommended`.

## Why
Standardising Renovate config placement and shared-preset usage across `sneat-co` repos: `renovate.json` under `.github/`, extending `github>sneat-co/cicd`. This matches the now-majority fleet convention (e.g. `sneat-co/assetus`).

## config:base -> config:recommended normalization
This repo's `extends` previously used `config:base`, Renovate's old/deprecated name for `config:recommended` (renamed upstream some time ago; `config:base` is now just a deprecated alias that triggers a warning). This PR switches to the current name `config:recommended`. This is **not a behavioral change** — same preset, current name — and brings this repo in line with the identical, already-canonical config used across the rest of the fleet.

## Scope
Renovate config only — no workflow, CI, or dependency changes.